### PR TITLE
Add terms to SPGooglePlacesAutocompletePlace

### DIFF
--- a/SPGooglePlacesAutocomplete/SPGooglePlacesAutocompletePlace.h
+++ b/SPGooglePlacesAutocomplete/SPGooglePlacesAutocompletePlace.h
@@ -42,6 +42,11 @@
 @property (nonatomic, strong) NSString *key;
 
 /*!
+ Contains the separate terms that make up the returned result's name
+ */
+@property (nonatomic, strong, readonly) NSArray *terms;
+
+/*!
  Resolves the place to a CLPlacemark, issuing  Google Place Details request if needed.
  */
 - (void)resolveToPlacemark:(SPGooglePlacesPlacemarkResultBlock)block;

--- a/SPGooglePlacesAutocomplete/SPGooglePlacesAutocompletePlace.m
+++ b/SPGooglePlacesAutocomplete/SPGooglePlacesAutocompletePlace.m
@@ -14,6 +14,7 @@
 @property (nonatomic, strong) NSString *reference;
 @property (nonatomic, strong) NSString *identifier;
 @property (nonatomic) SPGooglePlacesAutocompletePlaceType type;
+@property (nonatomic, strong) NSArray* terms;
 @end
 
 @implementation SPGooglePlacesAutocompletePlace
@@ -25,6 +26,10 @@
     place.reference = placeDictionary[@"reference"];
     place.identifier = placeDictionary[@"id"];
     place.type = SPPlaceTypeFromDictionary(placeDictionary);
+    NSMutableArray* terms = [NSMutableArray array];
+    for (NSDictionary* term in [placeDictionary objectForKey:@"terms"])
+        [terms addObject:term[@"value"]];
+    place.terms = terms;
     place.key = apiKey;
     return place;
 }


### PR DESCRIPTION
Extracts the terms identifying each section of the returned description and exposes them as a `terms` property